### PR TITLE
[IDEA] Feat: Add color scheme switcher and option to hide KDE Connect 

### DIFF
--- a/package/contents/config/config.qml
+++ b/package/contents/config/config.qml
@@ -1,3 +1,4 @@
+import org.kde.plasma.plasmoid 2.0
 import org.kde.plasma.configuration 2.0
 
 ConfigModel {
@@ -5,5 +6,11 @@ ConfigModel {
         name: i18n("Appearance")
         icon: "preferences-desktop-color"
         source: "configAppearance.qml"
+    }
+    ConfigCategory {
+        name: i18n("Color schemes")
+        icon: "color-picker"
+        source: "configColorscheme.qml"
+        visible: Plasmoid.configuration.showColorSwitcher
     }
 }

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -26,5 +26,8 @@
             <label>Dark Theme</label>
             <default>BreezeDark</default>
         </entry>
+        <entry name="hideKdeConnect" type="bool">
+            <default>true</default>
+        </entry>
     </group>
 </kcfg>

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -12,5 +12,19 @@
         <entry name="transparency" type="Bool">
             <default>False</default>
         </entry>
+        <entry name="showColorSwitcher" type="bool">
+            <default>false</default>
+        </entry>
+        <entry name="isDarkTheme" type="bool">
+            <default>false</default>
+        </entry>
+        <entry name="lightTheme" type="String">
+            <label>Light Theme</label>
+            <default>BreezeLight</default>
+        </entry>
+        <entry name="darkTheme" type="String">
+            <label>Dark Theme</label>
+            <default>BreezeDark</default>
+        </entry>
     </group>
 </kcfg>

--- a/package/contents/ui/FullRepresentation.qml
+++ b/package/contents/ui/FullRepresentation.qml
@@ -61,6 +61,24 @@ Item {
     Layout.minimumHeight: Layout.preferredHeight
     Layout.maximumHeight: Layout.preferredHeight
     clip: true
+
+    PlasmaCore.DataSource {
+        id: executable
+        engine: "executable"
+        connectedSources: []
+        onNewData: { 
+            disconnectSource(sourceName)
+        }
+        
+        function exec(cmd) {
+            connectSource(cmd)
+        }
+
+        function swapColorScheme() {
+            var colorSchemeName = Plasmoid.configuration.isDarkTheme ? Plasmoid.configuration.lightTheme : Plasmoid.configuration.darkTheme
+            exec("plasma-apply-colorscheme " + colorSchemeName)
+        }
+    }
     
     ColumnLayout {
         id: wrapper
@@ -239,6 +257,21 @@ Item {
                 onClicked: {
                     Funcs.toggleRedshiftInhibition();
                 }
+                visible: !Plasmoid.configuration.showColorSwitcher
+            }
+            Lib.CardButton {
+                Layout.preferredWidth: parent.width/4
+                Layout.preferredHeight: wrapper.height/4
+                title: i18n(Plasmoid.configuration.isDarkTheme ? "Light Theme" : "Dark Theme")
+                PlasmaCore.IconItem {
+                    anchors.fill: parent
+                    source: Plasmoid.configuration.isDarkTheme ? "brightness-high" : "brightness-low"
+                }
+                onClicked: {
+                    executable.swapColorScheme();
+                    Plasmoid.configuration.isDarkTheme = !Plasmoid.configuration.isDarkTheme
+                }
+                visible: Plasmoid.configuration.showColorSwitcher
             }
         }
         ColumnLayout {

--- a/package/contents/ui/FullRepresentation.qml
+++ b/package/contents/ui/FullRepresentation.qml
@@ -245,9 +245,10 @@ Item {
                     source: "kdeconnect-tray"
                 }
                 onClicked: KdeConnect.OpenConfig.openConfiguration();
+                visible: !Plasmoid.configuration.hideKdeConnect
             }
             Lib.CardButton {
-                Layout.preferredWidth: parent.width/4
+                Layout.preferredWidth: Plasmoid.configuration.hideKdeConnect ? parent.width/2 : parent.width/4
                 Layout.preferredHeight: wrapper.height/4
                 title: i18n("Night Color")
                 PlasmaCore.IconItem {
@@ -260,7 +261,7 @@ Item {
                 visible: !Plasmoid.configuration.showColorSwitcher
             }
             Lib.CardButton {
-                Layout.preferredWidth: parent.width/4
+                Layout.preferredWidth: Plasmoid.configuration.hideKdeConnect ? parent.width/2 : parent.width/4
                 Layout.preferredHeight: wrapper.height/4
                 title: i18n(Plasmoid.configuration.isDarkTheme ? "Light Theme" : "Dark Theme")
                 PlasmaCore.IconItem {

--- a/package/contents/ui/FullRepresentation.qml
+++ b/package/contents/ui/FullRepresentation.qml
@@ -16,6 +16,7 @@ import org.kde.plasma.private.nightcolorcontrol 1.0 as Redshift
 import org.kde.plasma.private.volume 0.1 as Vol
 
 import "lib" as Lib
+import "components" as Components
 import "funcs.js" as Funcs 
 
 
@@ -62,24 +63,6 @@ Item {
     Layout.maximumHeight: Layout.preferredHeight
     clip: true
 
-    PlasmaCore.DataSource {
-        id: executable
-        engine: "executable"
-        connectedSources: []
-        onNewData: { 
-            disconnectSource(sourceName)
-        }
-        
-        function exec(cmd) {
-            connectSource(cmd)
-        }
-
-        function swapColorScheme() {
-            var colorSchemeName = Plasmoid.configuration.isDarkTheme ? Plasmoid.configuration.lightTheme : Plasmoid.configuration.darkTheme
-            exec("plasma-apply-colorscheme " + colorSchemeName)
-        }
-    }
-    
     ColumnLayout {
         id: wrapper
 
@@ -260,18 +243,7 @@ Item {
                 }
                 visible: !Plasmoid.configuration.showColorSwitcher
             }
-            Lib.CardButton {
-                Layout.preferredWidth: Plasmoid.configuration.hideKdeConnect ? parent.width/2 : parent.width/4
-                Layout.preferredHeight: wrapper.height/4
-                title: i18n(Plasmoid.configuration.isDarkTheme ? "Light Theme" : "Dark Theme")
-                PlasmaCore.IconItem {
-                    anchors.fill: parent
-                    source: Plasmoid.configuration.isDarkTheme ? "brightness-high" : "brightness-low"
-                }
-                onClicked: {
-                    executable.swapColorScheme();
-                    Plasmoid.configuration.isDarkTheme = !Plasmoid.configuration.isDarkTheme
-                }
+            Components.ColorSchemeSwitcher {
                 visible: Plasmoid.configuration.showColorSwitcher
             }
         }

--- a/package/contents/ui/components/ColorSchemeSwitcher.qml
+++ b/package/contents/ui/components/ColorSchemeSwitcher.qml
@@ -1,0 +1,45 @@
+import QtQml 2.0
+import QtQuick 2.0
+import QtQuick.Layouts 1.15
+import QtQuick.Controls 2.0
+
+import org.kde.plasma.plasmoid 2.0
+import org.kde.plasma.core 2.0 as PlasmaCore
+
+import "../lib" as Lib
+
+
+Lib.CardButton {
+    id: colorSchemeSwitcher
+
+    Layout.preferredWidth: Plasmoid.configuration.hideKdeConnect ? parent.width/2 : parent.width/4
+    Layout.preferredHeight: wrapper.height/4
+    title: i18n(Plasmoid.configuration.isDarkTheme ? "Light Theme" : "Dark Theme")
+    PlasmaCore.IconItem {
+        anchors.fill: parent
+        source: Plasmoid.configuration.isDarkTheme ? "brightness-high" : "brightness-low"
+    }
+
+    onClicked: {
+        executable.swapColorScheme();
+        Plasmoid.configuration.isDarkTheme = !Plasmoid.configuration.isDarkTheme
+    }
+
+    PlasmaCore.DataSource {
+        id: executable
+        engine: "executable"
+        connectedSources: []
+        onNewData: { 
+            disconnectSource(sourceName)
+        }
+        
+        function exec(cmd) {
+            connectSource(cmd)
+        }
+
+        function swapColorScheme() {
+            var colorSchemeName = Plasmoid.configuration.isDarkTheme ? Plasmoid.configuration.lightTheme : Plasmoid.configuration.darkTheme
+            exec("plasma-apply-colorscheme " + colorSchemeName)
+        }
+    }
+}

--- a/package/contents/ui/configAppearance.qml
+++ b/package/contents/ui/configAppearance.qml
@@ -9,6 +9,7 @@ ColumnLayout {
     property alias cfg_scale: scale.value
     property alias cfg_transparency: transparency.checked
     property alias cfg_showColorSwitcher: showColorSwitcher.checked
+    property alias cfg_hideKdeConnect: hideKdeConnect.checked
     
     PlasmaExtras.Heading {
         text: i18n("Settings")
@@ -39,6 +40,14 @@ ColumnLayout {
         }
         CheckBox {
             id: showColorSwitcher 
+        }
+    }
+    RowLayout {
+        Label {
+            text: i18n("Hide KDE Connect")
+        }
+        CheckBox {
+            id: hideKdeConnect 
         }
     }
     

--- a/package/contents/ui/configAppearance.qml
+++ b/package/contents/ui/configAppearance.qml
@@ -8,6 +8,7 @@ import org.kde.plasma.extras 2.0 as PlasmaExtras
 ColumnLayout {
     property alias cfg_scale: scale.value
     property alias cfg_transparency: transparency.checked
+    property alias cfg_showColorSwitcher: showColorSwitcher.checked
     
     PlasmaExtras.Heading {
         text: i18n("Settings")
@@ -31,6 +32,14 @@ ColumnLayout {
     }
     Label {
         text: i18n("Transparency might not work correctly with some themes!")
+    }
+    RowLayout {
+        Label {
+            text: i18n("Replace Night Color with Color Scheme Switcher")
+        }
+        CheckBox {
+            id: showColorSwitcher 
+        }
     }
     
     Item {

--- a/package/contents/ui/configColorscheme.qml
+++ b/package/contents/ui/configColorscheme.qml
@@ -1,0 +1,117 @@
+import QtQml 2.0
+import QtQuick 2.0
+import QtQuick.Controls 2.0
+import QtQuick.Layouts 1.0
+import org.kde.plasma.core 2.0 as PlasmaCore
+import org.kde.plasma.extras 2.0 as PlasmaExtras
+
+Item {
+    property alias cfg_lightTheme: labelA.text // labels to store previous choices (ComboBox doesn't like to do it by itself)
+    property alias cfg_darkTheme: labelB.text // labels to store previous choices (ComboBox doesn't like to do it by itself)
+    
+    PlasmaCore.DataSource {
+        id: executable
+        engine: "executable"
+        connectedSources: []
+
+        signal colorsListReady(var colors)
+
+        function exec(cmd) {
+            connectSource(cmd)
+        }
+
+        onNewData: {
+            var colors = data["stdout"].split("\n")
+            for (var i = 0; i < colors.length; i++) // parse command output
+                colors[i] = colors[i].substring(3).replace(" (current color scheme)", "")
+                colorsListReady(colors)
+                disconnectSource(sourceName) // cmd finished
+        }
+
+    }
+
+    // Copies of the last saved ComboBox entries.
+    Label {
+        id: labelA
+        visible: false
+    }
+    Label {
+        id: labelB
+        visible: false
+    }
+
+    function setText(comboBox, text) { // comboboxes don't really allow to set current entry by text => manually search for them
+        var found = false
+        for (var colorIndex = 0; colorIndex < comboBox.count; colorIndex++) {
+            if (comboBox.currentText === text) {
+                found = true
+                break
+            }
+            comboBox.incrementCurrentIndex()
+        }
+        if (!found)
+            console.log("Color not found (perhaps it has been removed?).")
+    }
+
+    Connections {
+        target: executable
+        onColorsListReady: {
+            cBoxA.model = colors
+            cBoxB.model = colors
+            // look for color in list
+            setText(cBoxA, labelA.text)
+            setText(cBoxB, labelB.text)
+            // enable changes user just after everything is set up
+            cBoxA.isChangeAvailable = true
+            cBoxB.isChangeAvailable = true
+        }
+    }
+
+    ColumnLayout {
+        GridLayout {
+            columns: 2
+            Label {
+                Layout.row :0
+                Layout.column: 0
+                text: i18n("Light color")
+            }
+
+            ComboBox {
+                id: cBoxA
+                property bool isChangeAvailable: false
+
+                Layout.row: 0
+                Layout.column: 1
+                Layout.minimumWidth: 300
+                onCurrentTextChanged: {
+                    if (isChangeAvailable)
+                        labelA.text = currentText
+                }
+            }
+
+            Label {
+                Layout.row :1
+                Layout.column: 0
+                text: i18n("Dark color")
+            }
+
+            ComboBox {
+                id: cBoxB
+                property bool isChangeAvailable: false
+
+                Layout.row: 1
+                Layout.column: 1
+                Layout.minimumWidth: 300
+
+                onCurrentTextChanged: {
+                    if (isChangeAvailable)
+                        labelB.text = currentText
+                }
+            }
+        }
+    }
+
+    Component.onCompleted: {
+        executable.exec("plasma-apply-colorscheme --list-schemes | tail --lines=+2")
+    }
+}


### PR DESCRIPTION
Hi!
This PR is just an idea of what could be done to make this widget even better.
The first idea is to add an option to hide KDE Connect. Some people don't use and, I don't think that this is a crucial item to be there, all the time, to everyone. So, we could just start with it disabled and, if the user want, enable it in the configuration.
The second idea is based on [this widget](https://store.kde.org/p/1804745) ([repo here](https://github.com/heqro/colorschemeswapper-plasmoid)). This is a very nice widget to select two color scheme to swap between. So, the user could select a light theme and a dark theme and just switch between them in a click of a button.
The problem with this second one is the bunch of code, it don't seem to me like very good so, we can remove this option to let the user select between the color scheme and just hardcode "BreezeLight" and "BreezeDark" there.

https://user-images.githubusercontent.com/33737137/194538837-763bab5f-d701-48de-9511-b0603f11c5a9.mp4