### PR TITLE
WIP - Initial brightness control with automatic detection based on PowerDevil

### DIFF
--- a/package/contents/ui/BrightnessSlider.qml
+++ b/package/contents/ui/BrightnessSlider.qml
@@ -4,22 +4,19 @@ import QtQuick.Layouts 1.15
 import org.kde.plasma.core 2.0 as PlasmaCore
 import org.kde.plasma.components 2.0 as PlasmaComponents
 import "lib" as Lib
+
+
 Lib.Slider {
-    // FIXME: Need Help! I don't have a monitor that supports changing brightness from the PC itself.
-    // Need someone to test this!
-    visible: false
+    visible: root.isBrightnessAvailable
     Layout.preferredWidth: parent.width
     Layout.preferredHeight: wrapper.height/4
-    title: "Brightness"
+    title: "Display Brightness"
     source: "brightness-high"
+    from: 0
+    to: root.maximumScreenBrightness
+    value: root.screenBrightness
+    onMoved: {
+        root.screenBrightness = value
+    }
     
-    // PlasmaCore.DataSource {
-    //     id: powerSource
-    //     engine: "powermanagement"
-    //     connectedSources: ["PowerDevil"]
-    //     onDataChanged: {
-    //         var powerData = data["PowerDevil"]
-    //         console.log(powerData)
-    //     }
-    // }
 }

--- a/package/contents/ui/brightness.js
+++ b/package/contents/ui/brightness.js
@@ -1,0 +1,21 @@
+
+function updateBrightness(rootItem, source) {
+    if (rootItem.updateScreenBrightnessJob || rootItem.updateKeyboardBrightnessJob)
+        return;
+
+    if (!source.data["PowerDevil"]) {
+        return;
+    }
+
+    // we don't want passive brightness change send setBrightness call
+    rootItem.disableBrightnessUpdate = true;
+
+    if (typeof source.data["PowerDevil"]["Screen Brightness"] === 'number') {
+        rootItem.screenBrightness = source.data["PowerDevil"]["Screen Brightness"];
+    }
+    if (typeof source.data["PowerDevil"]["Keyboard Brightness"] === 'number') {
+        rootItem.keyboardBrightness = source.data["PowerDevil"]["Keyboard Brightness"];
+    }
+    rootItem.disableBrightnessUpdate = false;
+}
+

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -1,7 +1,11 @@
 import QtQuick 2.0
 import QtQuick.Controls 2.15
 import org.kde.plasma.plasmoid 2.0
-import org.kde.plasma.core 2.0 as PlasmaCore
+import org.kde.plasma.core 2.1 as PlasmaCore
+
+import "brightness.js" as BrightnessJS
+
+
 
 Item {
     id: root
@@ -27,6 +31,45 @@ Item {
     property int largeFontSize: 12 * scale
     property int mediumFontSize: 10 * scale
     property int smallFontSize: 6 * scale
+
+    // Screen brightness properties 
+    property int screenBrightness
+    property QtObject updateScreenBrightnessJob
+    property bool disableBrightnessUpdate: true
+
+
+    property QtObject pmSource: PlasmaCore.DataSource {
+        id: pmSource
+        engine: "powermanagement"
+        connectedSources: sources
+        onSourceAdded: {
+            disconnectSource(source);
+            connectSource(source);
+        }
+        onSourceRemoved: {
+            disconnectSource(source);
+        }
+        onDataChanged: {
+            BrightnessJS.updateBrightness(root, pmSource);
+        }
+    }
+
+        onScreenBrightnessChanged: {
+        if (disableBrightnessUpdate) {
+            return;
+        }
+        const service = pmSource.serviceForSource("PowerDevil");
+        const operation = service.operationDescription("setBrightness");
+        operation.brightness = screenBrightness;
+        updateScreenBrightnessJob = service.startOperationCall(operation);
+        updateScreenBrightnessJob.finished.connect(job => {
+            BrightnessJS.updateBrightness(root, pmSource);
+        });
+    }
+
+
+    readonly property bool isBrightnessAvailable: pmSource.data["PowerDevil"] && pmSource.data["PowerDevil"]["Screen Brightness Available"] ? true : false
+    readonly property int maximumScreenBrightness: pmSource.data["PowerDevil"] ? pmSource.data["PowerDevil"]["Maximum Screen Brightness"] || 0 : 0
 
     Plasmoid.fullRepresentation: FullRepresentation {}
     //Plasmoid.compactRepresentation: CompactRepresentation {}


### PR DESCRIPTION
I added brightness properties and  external JS file for brightness value update (most of the work got from original plasma-workspace brightness control) I just make it work with current slider and It does do detection of current brightness value. 

I added WIP because I need to handle position of brightness card because It is overlaying media player and preventing to show it. I am working on that problem. 

FIX : https://github.com/Prayag2/kde_controlcentre/issues/1