### PR TITLE
improvement: add a separate for support in the configure dialog

### DIFF
--- a/package/contents/config/config.qml
+++ b/package/contents/config/config.qml
@@ -13,4 +13,9 @@ ConfigModel {
         source: "config/configColorscheme.qml"
         visible: Plasmoid.configuration.showColorSwitcher
     }
+    ConfigCategory {
+        name: i18n("Support")
+        icon: "face-angel"
+        source: "config/configSupport.qml"
+    }
 }

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -32,4 +32,6 @@
             <default>true</default>
         </entry>
     </group>
+    <group name="Support">
+    </group>
 </kcfg>

--- a/package/contents/ui/config/configAppearance.qml
+++ b/package/contents/ui/config/configAppearance.qml
@@ -54,49 +54,4 @@ ColumnLayout {
     Item {
         Layout.fillHeight: true
     }
-    ColumnLayout {
-        Layout.fillHeight: true
-        Layout.fillWidth: true
-        
-        PlasmaExtras.Heading {
-            text: i18n("If you'd like to support me :)")
-        }
-        Row {
-            spacing: 10
-            height: PlasmaCore.Units.gridUnit * 2.5
-            Image {
-                height: parent.height
-                source: "../assets/LiberaPay.png"
-                fillMode: Image.PreserveAspectFit
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: {
-                        Qt.openUrlExternally("https://liberapay.com/Prayag/donate")
-                    }
-                }
-            }
-            Image {
-                height: parent.height
-                source: "../assets/Paypal.png"
-                fillMode: Image.PreserveAspectFit
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: {
-                        Qt.openUrlExternally("https://coindrop.to/prayagjain")
-                    }
-                }
-            }
-            Image {
-                height: parent.height
-                source: "../assets/Ko-Fi.png"
-                fillMode: Image.PreserveAspectFit
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: {
-                        Qt.openUrlExternally("https://ko-fi.com/O5O1FJ70D")
-                    }
-                }
-            }
-        }
-    }
 }

--- a/package/contents/ui/config/configSupport.qml
+++ b/package/contents/ui/config/configSupport.qml
@@ -1,0 +1,55 @@
+import QtQml 2.0
+import QtQuick 2.0
+import QtQuick.Controls 2.0
+import QtQuick.Layouts 1.0
+import org.kde.plasma.core 2.0 as PlasmaCore
+import org.kde.plasma.extras 2.0 as PlasmaExtras
+
+ColumnLayout {
+    Layout.fillHeight: true
+    Layout.fillWidth: true
+    
+    PlasmaExtras.Heading {
+        text: i18n("If you'd like to support me :)")
+    }
+    Row {
+        spacing: 10
+        height: PlasmaCore.Units.gridUnit * 2.5
+        Image {
+            height: parent.height
+            source: "../../assets/LiberaPay.png"
+            fillMode: Image.PreserveAspectFit
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    Qt.openUrlExternally("https://liberapay.com/Prayag/donate")
+                }
+            }
+        }
+        Image {
+            height: parent.height
+            source: "../../assets/Paypal.png"
+            fillMode: Image.PreserveAspectFit
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    Qt.openUrlExternally("https://coindrop.to/prayagjain")
+                }
+            }
+        }
+        Image {
+            height: parent.height
+            source: "../../assets/Ko-Fi.png"
+            fillMode: Image.PreserveAspectFit
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    Qt.openUrlExternally("https://ko-fi.com/O5O1FJ70D")
+                }
+            }
+        }
+    }
+    Item {
+        Layout.fillHeight: true
+    }
+}


### PR DESCRIPTION
Created a separate page for "Support" in the configure dialog.
Previously, the donation buttons were present in the "Appearance" section which was quite unprofessional.
![image](https://user-images.githubusercontent.com/39525869/195249522-59b3e6ad-78df-407b-87d9-cadd3fba8ed3.png)
