### PR TITLE
Feature: Even more custom actions

### DIFF
--- a/package/contents/config/config.qml
+++ b/package/contents/config/config.qml
@@ -14,6 +14,11 @@ ConfigModel {
         visible: Plasmoid.configuration.showColorSwitcher
     }
     ConfigCategory {
+        name: i18n("Custom actions")
+        icon: "new-command-alarm"
+        source: "config/configCustomActions.qml"
+    }
+    ConfigCategory {
         name: i18n("Support")
         icon: "face-angel"
         source: "config/configSupport.qml"

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -81,5 +81,10 @@
         <entry name="cmdIcon2" type="string">
             <default>system-run-symbolic</default>
         </entry>
+
+        <!-- Custom actions -->
+        <entry name="customActions" type="string">
+            <default>[]</default>
+        </entry>
     </group>
 </kcfg>

--- a/package/contents/ui/FullRepresentation.qml
+++ b/package/contents/ui/FullRepresentation.qml
@@ -77,9 +77,11 @@ Item {
                 }
             }
         }
+
         Item {
             Layout.fillHeight: true
         }
+
         ColumnLayout {
             id: sectionB
 
@@ -90,7 +92,20 @@ Item {
             Components.BrightnessSlider{}
             Components.MediaPlayer{}
         }
-        
 
+        Item {
+            Layout.fillHeight: true
+        }
+
+        // Custom Actions section
+        GridLayout {
+            id: sectionC
+
+            Layout.fillWidth: true
+            rows: 2
+            columns: 4
+            
+            Component.onCompleted: Funcs.generateCustomActions(plasmoid.configuration.customActions);
+        }
     }
 }

--- a/package/contents/ui/components/CommandRun.qml
+++ b/package/contents/ui/components/CommandRun.qml
@@ -8,11 +8,15 @@ import "../lib" as Lib
 import "../js/funcs.js" as Funcs
 
 Lib.CardButton {
-    Layout.fillWidth: true
-    Layout.fillHeight: true
     property string icon;
     property string command;
+    property bool isSmall;
     
+    Layout.fillWidth: true
+    Layout.fillHeight: !isSmall
+
+    Layout.preferredHeight: isSmall ? root.sectionHeight / 2 : undefined
+
     function exec(cmd) {
         executable.connectSource(cmd)
     }

--- a/package/contents/ui/components/CustomActionConfig.qml
+++ b/package/contents/ui/components/CustomActionConfig.qml
@@ -1,0 +1,71 @@
+import QtQml 2.15
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import org.kde.kirigami 2.15 as Kirigami
+import org.kde.kquickcontrolsaddons 2.0 as KQuickAddons
+import org.kde.plasma.core 2.0 as PlasmaCore
+import org.kde.plasma.extras 2.0 as PlasmaExtras
+
+import "../js/funcs.js" as Funcs
+
+ColumnLayout {
+    property string customIcon;
+    property string command;
+    property string title;
+
+    id: customAction
+
+    // Used to select icons
+    KQuickAddons.IconDialog {
+        id: iconDialog
+        property var iconObj
+        
+        onIconNameChanged: customIcon = iconName
+        
+    }
+
+    Kirigami.FormLayout {
+        RowLayout {
+            Kirigami.FormData.label: i18n("Icon and Name:")
+
+            Button {
+                icon.name: customIcon
+                icon.width: PlasmaCore.Units.iconSizes.medium
+                icon.height: icon.width
+                onClicked: {
+                    iconDialog.open()
+                }
+            }
+
+            TextField {
+                Layout.fillWidth: true
+                placeholderText: "Custom command name"
+                text: title;
+                onTextEdited: {
+                    title = this.text
+                }
+            }
+        }
+
+        TextField {
+            Kirigami.FormData.label: i18n("Command:")
+            placeholderText: "Custom command"
+            text: command;
+            onTextEdited: {
+                command = this.text
+            }
+        }
+
+        Button {
+            Layout.fillWidth: true
+            text: "Remove"
+            onClicked: Funcs.destroyObject(customAction)
+        }
+
+        Kirigami.Separator {
+            Kirigami.FormData.isSection: true
+        }
+    }
+}

--- a/package/contents/ui/config/configCustomActions.qml
+++ b/package/contents/ui/config/configCustomActions.qml
@@ -1,0 +1,73 @@
+import QtQml 2.15
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import org.kde.kirigami 2.15 as Kirigami
+import org.kde.kquickcontrolsaddons 2.0 as KQuickAddons
+import org.kde.plasma.core 2.0 as PlasmaCore
+import org.kde.plasma.extras 2.0 as PlasmaExtras
+
+import "../components" as Components
+import "../js/funcs.js" as Funcs
+
+ColumnLayout {
+    id: configCustomActions
+
+    property alias cfg_customActions: customActions.text
+
+    Layout.fillHeight: true
+    Layout.fillWidth: true
+
+    Kirigami.FormLayout {
+        TextField {
+            id: customActions
+            Layout.fillWidth: true
+            enabled: false
+            visible: false
+        }
+
+        ColumnLayout {
+            id: customActionsConfigColumn
+
+            Component.onCompleted: Funcs.generateCustomActionsConfiguration(plasmoid.configuration.customActions);
+        }
+
+        Button {
+            Layout.fillWidth: true
+            text: "Add new action"
+            onClicked: {
+                Funcs.addObject();
+            }
+        }
+
+        Label {
+            text: "You should apply and restart your plasmashell to see your changes."
+            color: PlasmaCore.Theme.neutralTextColor
+        }
+
+        Button {
+            id: restartPlasmashellButton
+            Layout.fillWidth: true
+            text: "Save changes"
+            enabled: customActions.text === plasmoid.configuration.customActions
+            onClicked: {
+                customActions.text = Funcs.saveJSON(customActionsConfigColumn);
+            }
+        }
+    }
+    
+    function exec(cmd) {
+        executable.connectSource(cmd)
+    }
+    
+    PlasmaCore.DataSource {
+        id: executable
+        engine: "executable"
+        connectedSources: []
+
+        onNewData: {
+            disconnectSource(connectedSources)
+        }
+    }
+}

--- a/package/contents/ui/js/funcs.js
+++ b/package/contents/ui/js/funcs.js
@@ -99,6 +99,7 @@ function changeVolumeByPercent(volumeObject, deltaPercent) {
     volumeObject.volume = newVolume;
     return newPercent;
 }
+
 function volIconName(volume, muted, prefix) {
     if (!prefix) {
         prefix = "audio-volume";
@@ -115,4 +116,60 @@ function volIconName(volume, muted, prefix) {
         icon = prefix + "-high";
     }
     return icon;
+}
+
+function generateCustomActions(customActionsConfigurationString) {
+    const component = Qt.createComponent("../components/CommandRun.qml");
+    const parsedCustomActions = JSON.parse(customActionsConfigurationString || '[]');
+
+
+    parsedCustomActions.forEach((customAction) => {
+        const temp = component.createObject(sectionC);
+
+        temp.title = customAction.name;
+        temp.command = customAction.command;
+        temp.icon = customAction.icon;
+        temp.visible = true;
+        temp.isSmall = true;
+
+        if (temp == null) {
+            console.log('Error creating object');
+        }
+    })
+}
+
+function generateCustomActionsConfiguration(customActionsConfigurationString) {
+    const component = Qt.createComponent("../components/CustomActionConfig.qml");
+    const parsedCustomActions = JSON.parse(customActionsConfigurationString || '[]');
+
+
+    parsedCustomActions.forEach((customAction) => {
+        const temp = component.createObject(customActionsConfigColumn);
+
+        temp.title = customAction.name;
+        temp.command = customAction.command;
+        temp.customIcon = customAction.icon;
+
+        if (temp == null) {
+            console.log('Error creating object');
+        }
+    })
+}
+
+function saveJSON(object) {
+    const newConfig = Array.from(object.children).map(child => {
+        return { name: child.title, icon: child.customIcon, command: child.command }
+    })
+
+    return JSON.stringify(newConfig);
+}
+
+function destroyObject(object) {
+    object.destroy();
+}
+
+function addObject() {
+    const component = Qt.createComponent("../components/CustomActionConfig.qml");
+
+    component.createObject(customActionsConfigColumn);
 }

--- a/package/contents/ui/lib/CardButton.qml
+++ b/package/contents/ui/lib/CardButton.qml
@@ -12,7 +12,7 @@ Card {
 
     GridLayout {
         anchors.fill: parent
-        property bool small: width < root.fullRepWidth/4
+        property bool small: width < root.fullRepWidth/3
         anchors.margins: small ? root.smallSpacing : root.largeSpacing
         rows: small ? 2 : 1
         columns: small ? 1 : 2


### PR DESCRIPTION
When you first talked about custom actions I thought in something like that.
A new area in configuration where the user can add and remove how many actions he wants.
This is not complete, but is functional.
I guess that, to be complete, we should:
1. Prevent user to save if one of the information is empty (icon, name or command);
2. Discover a way to refresh the widget after the user apply the new configuration, without have to restart the plasmashell.
3. Let the user decide where to show the custom actions grid (for example in the bottom, above volume slider or at the top) 

I think that, if you decide to follow through this path, we should remove the option to replace KDE Connect, Night Color and the Color Swapper icon to custom actions.

https://user-images.githubusercontent.com/33737137/197253613-88470857-0a4b-456a-9d9e-9e3c43360f59.mp4
