### PR TITLE
Add support for inset margins of FrameSvgItems

### DIFF
--- a/package/contents/ui/lib/Card.qml
+++ b/package/contents/ui/lib/Card.qml
@@ -19,14 +19,18 @@ Rectangle {
         imagePath: root.enableTransparency ? "translucent/dialogs/background" : "opaque/dialogs/background"
         clip: true
         anchors.fill: parent
-        anchors.topMargin: rect.margins.top * root.scale
-        anchors.leftMargin: rect.margins.left * root.scale
-        anchors.rightMargin: rect.margins.right * root.scale
-        anchors.bottomMargin: rect.margins.bottom * root.scale
+        anchors.topMargin: -rect.inset.top + PlasmaCore.Units.smallSpacing * 1.5
+        anchors.leftMargin: -rect.inset.left  + PlasmaCore.Units.smallSpacing * 1.5
+        anchors.rightMargin: -rect.inset.right  + PlasmaCore.Units.smallSpacing * 1.5
+        anchors.bottomMargin: -rect.inset.bottom  + PlasmaCore.Units.smallSpacing * 1.5
 
         Item {
             id: dataContainer
             anchors.fill: parent
+            anchors.topMargin: rect.margins.top-rect.inset.top
+            anchors.leftMargin: rect.margins.left -rect.inset.left
+            anchors.rightMargin: rect.margins.right -rect.inset.right
+            anchors.bottomMargin: rect.margins.bottom -rect.inset.bottom
         }
     }
 }


### PR DESCRIPTION
SVG items can currently define a "inset" property that defines how much inset the element should have. The use case for this is e.g. including a shadow around the element and then setting the inset to be the same size as the shadow.

The idea is that this shouldn't change much unless you're using inset. However, I do change how margins work, since they were previously used to define the margin outside the element, and now they're used to define the margin inside them, as I thought was more appropriate.