### PR TITLE
(feat) Plasma Desktop Theme Switcher

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -29,6 +29,14 @@
             <label>Dark Theme</label>
             <default>BreezeDark</default>
         </entry>
+        <entry name="lightPlasmaTheme" type="String">
+            <label>Plasma Theme (Light)</label>
+            <default>breeze-light</default>
+        </entry>
+        <entry name="darkPlasmaTheme" type="String">
+            <label>Plasma Theme (Dark)</label>
+            <default>breeze-dark</default>
+        </entry>
 
         <!--    BEHAVIOUR      -->
         <entry name="playVolumeFeedback" type="Bool">

--- a/package/contents/ui/components/ColorSchemeSwitcher.qml
+++ b/package/contents/ui/components/ColorSchemeSwitcher.qml
@@ -39,9 +39,12 @@ Lib.CardButton {
         function swapColorScheme() {
             var usingDark = isDarkTheme();
             var colorSchemeName = usingDark ? Plasmoid.configuration.lightTheme : Plasmoid.configuration.darkTheme;
+            var plasmaThemeName = usingDark ? Plasmoid.configuration.lightPlasmaTheme : Plasmoid.configuration.darkPlasmaTheme;
+
             Plasmoid.configuration.isDarkTheme = !usingDark ? 1 : 0;
 
-            exec("plasma-apply-colorscheme " + colorSchemeName)
+            exec("plasma-apply-colorscheme " + colorSchemeName +
+                ";plasma-apply-desktoptheme " + plasmaThemeName);
         }
     }
 

--- a/package/contents/ui/components/ConfigAppearanceComboBox.qml
+++ b/package/contents/ui/components/ConfigAppearanceComboBox.qml
@@ -1,0 +1,29 @@
+import QtQml
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+
+ComboBox {
+    property bool isChangeAvailable: false
+    property string lastText: ""
+
+    Layout.column: 1
+    Layout.minimumWidth: 300
+
+    onCurrentTextChanged: {
+        if (!isChangeAvailable)
+            return;
+
+        lastText = currentText;
+    }
+
+    // Functions //
+
+    function configure(model) {
+        this.model = model
+
+        this.currentIndex = this.find(lastText);
+        this.isChangeAvailable = true
+    }
+}

--- a/package/contents/ui/components/ConfigAppearanceDataSource.qml
+++ b/package/contents/ui/components/ConfigAppearanceDataSource.qml
@@ -1,0 +1,79 @@
+import QtQuick
+import org.kde.plasma.plasma5support as PlasmaCore
+
+
+PlasmaCore.DataSource {
+    engine: "executable"
+    connectedSources: []
+
+    enum ItemType {
+        Unknown,
+        ColourThemes,
+        PlasmaThemes
+    }
+
+    property int lastItemType: ConfigAppearanceDataSource.ItemType.Unknown
+    property var typesToFetch: []
+
+    signal itemsReady(var items, var itemType)
+
+    onNewData: (sourceName, data) => {
+        disconnectSource(sourceName); // cmd finished
+
+        if (lastItemType == ConfigAppearanceDataSource.ItemType.Unknown)
+            return;
+
+        itemsReady(parseCommandOutput(data), lastItemType);
+        processNextFetchRequest();
+    }
+
+    // Functions //
+
+    function getItems() {
+        // TODO: Find a better way of doing this
+        typesToFetch = [
+            ConfigAppearanceDataSource.ItemType.ColourThemes,
+            ConfigAppearanceDataSource.ItemType.PlasmaThemes
+        ];
+
+        processNextFetchRequest();
+    }
+
+    function getItemsForType(itemType) {
+        if (itemType == ConfigAppearanceDataSource.ItemType.Unknown) {
+            processNextFetchRequest();
+            return;
+        }
+
+        this.lastItemType = itemType;
+
+        switch (itemType) {
+            case ConfigAppearanceDataSource.ItemType.ColourThemes:
+                connectSource("plasma-apply-colorscheme --list-schemes | tail --lines=+2");
+                break;
+
+            case ConfigAppearanceDataSource.ItemType.PlasmaThemes:
+                connectSource("plasma-apply-desktoptheme --list-themes | tail --lines=+2");
+                break;
+        }
+    }
+
+    function processNextFetchRequest() {
+        if (typesToFetch.length < 1)
+            return;
+
+        getItemsForType(typesToFetch.pop());
+    }
+
+    function parseCommandOutput(data) {
+        var items = data["stdout"].split("\n");
+
+        for (var i = 0; i < items.length; i++) {
+            items[i] = items[i]
+                .substring(3)
+                .split(" ")[0];
+        }
+
+        return items;
+    }
+}

--- a/package/contents/ui/config/configColorscheme.qml
+++ b/package/contents/ui/config/configColorscheme.qml
@@ -2,118 +2,113 @@ import QtQml
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import org.kde.plasma.plasma5support as PlasmaCore
-import org.kde.plasma.extras as PlasmaExtras
 import org.kde.kcmutils as KCM
 
+import "../components"
+import "../js/funcs.js" as Funcs
+
+
 KCM.SimpleKCM {
-    property alias cfg_lightTheme: labelA.text // labels to store previous choices (ComboBox doesn't like to do it by itself)
-    property alias cfg_darkTheme: labelB.text // labels to store previous choices (ComboBox doesn't like to do it by itself)
-
-    PlasmaCore.DataSource {
-        id: executable
-        engine: "executable"
-        connectedSources: []
-
-        signal colorsListReady(var colors)
-
-        function exec(cmd) {
-            connectSource(cmd)
-        }
-
-        onNewData: {
-            var colors = data["stdout"].split("\n")
-            console.log(colors)
-            for (var i = 0; i < colors.length; i++) // parse command output
-                colors[i] = colors[i].substring(3).split(" ")[0]
-                colorsListReady(colors)
-                disconnectSource(sourceName) // cmd finished
-        }
-
-    }
-
-    // Copies of the last saved ComboBox entries.
-    Label {
-        id: labelA
-        visible: false
-    }
-    Label {
-        id: labelB
-        visible: false
-    }
-
-    function setText(comboBox, text) { // comboboxes don't really allow to set current entry by text => manually search for them
-        var found = false
-        for (var colorIndex = 0; colorIndex < comboBox.count; colorIndex++) {
-            if (comboBox.currentText === text) {
-                found = true
-                break
-            }
-            comboBox.incrementCurrentIndex()
-        }
-        if (!found)
-            console.log("Color not found (perhaps it has been removed?).")
-    }
-
-    Connections {
-        target: executable
-        onColorsListReady: {
-            cBoxA.model = colors
-            cBoxB.model = colors
-            // look for color in list
-            setText(cBoxA, labelA.text)
-            setText(cBoxB, labelB.text)
-            // enable changes user just after everything is set up
-            cBoxA.isChangeAvailable = true
-            cBoxB.isChangeAvailable = true
-        }
-    }
+    property alias cfg_lightTheme: cboxLightColour.lastText
+    property alias cfg_darkTheme: cboxDarkColour.lastText
+    property alias cfg_lightPlasmaTheme: cboxLightPlasma.lastText
+    property alias cfg_darkPlasmaTheme: cboxDarkPlasma.lastText
 
     ColumnLayout {
         GridLayout {
             columns: 2
+
             Label {
-                Layout.row :0
-                Layout.column: 0
-                text: i18n("Light color")
-            }
-
-            ComboBox {
-                id: cBoxA
-                property bool isChangeAvailable: false
-
+                text: i18n("Colour Theme")
+                font.bold: true
                 Layout.row: 0
-                Layout.column: 1
-                Layout.minimumWidth: 300
-                onCurrentTextChanged: {
-                    if (isChangeAvailable)
-                        labelA.text = currentText
-                }
             }
 
+            // Light Colour Selection
             Label {
-                Layout.row :1
-                Layout.column: 0
-                text: i18n("Dark color")
-            }
-
-            ComboBox {
-                id: cBoxB
-                property bool isChangeAvailable: false
+                text: i18n("Light")
 
                 Layout.row: 1
-                Layout.column: 1
-                Layout.minimumWidth: 300
+                Layout.column: 0
+            }
 
-                onCurrentTextChanged: {
-                    if (isChangeAvailable)
-                        labelB.text = currentText
-                }
+            ConfigAppearanceComboBox {
+                id: cboxLightColour
+                Layout.row: 1
+            }
+
+            // Dark Colour selection
+            Label {
+                text: i18n("Dark")
+
+                Layout.row: 2
+                Layout.column: 0
+            }
+
+            ConfigAppearanceComboBox {
+                id: cboxDarkColour
+                Layout.row: 2
+            }
+
+            Label {
+                text: i18n("Plasma Theme")
+                font.bold: true
+                Layout.row: 3
+            }
+
+            // Light plasma theme selection
+            Label {
+                text: i18n("Light")
+
+                Layout.row: 4
+                Layout.column: 0
+            }
+
+            ConfigAppearanceComboBox {
+                id: cboxLightPlasma
+                Layout.row: 4
+            }
+
+            // Dark plasma theme selection
+            Label {
+                text: i18n("Dark")
+
+                Layout.row: 5
+                Layout.column: 0
+            }
+
+            ConfigAppearanceComboBox {
+                id: cboxDarkPlasma
+                Layout.row: 5
             }
         }
     }
 
     Component.onCompleted: {
-        executable.exec("plasma-apply-colorscheme --list-schemes | tail --lines=+2")
+        dataSource.getItems();
+    }
+
+    // Components //
+
+    ConfigAppearanceDataSource {
+        id: dataSource
+    }
+
+    Connections {
+        target: dataSource
+
+        onItemsReady: (items, itemType) => {
+            switch (itemType) {
+                case ConfigAppearanceDataSource.ItemType.ColourThemes:
+                    cboxLightColour.configure(items);
+                    cboxDarkColour.configure(items);
+                    break;
+
+                case ConfigAppearanceDataSource.ItemType.PlasmaThemes:
+                    cboxLightPlasma.configure(items);
+                    cboxDarkPlasma.configure(items);
+                    break;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR adds an option to change the plasma desktop theme alongside the colour scheme when using the **'Switch Appearance'** toggle.

## Purpose

Some theme makers often provide light and dark variations of their desktop themes.

Unfortunately, this introduces an issue when toggling between appearances as these packages may contain hardcoded colour overrides, rendering the light/dark switch effectively useless.

This option allows the user to specify which desktop theme to use when triggering the appearance toggle, giving them better control over their light/dark visual preferences.

## Changes

Most of the changes introduced in this PR are localised to files related to the appearance switcher function.

It also adds two configuration keys **'(light|dark)PlasmaTheme'** to **'config/main.xml'** to store the user's desktop theme preferences.

### Major(ish) changes:
- Refactored and moved the colour scheme combobox component into its own file **(Components/ConfigAppearanceComboBox.qml)**
- Moved the scheme switcher data source into its own file **(Components/ConfigAppearanceDataSource.qml)**
- Refactored the scheme switcher data source to make it easier to add more customisation options in the future.

## Preview

*(Note: Switching appearances is much faster than what is shown in this screencast. Having Spectacle record the screen, at the same time, seem to have slown it down by a fair bit.)*


https://github.com/Prayag2/kde_controlcentre/assets/46611929/dff3404a-1724-4b3b-a68d-db02957af470

